### PR TITLE
Specify the ruby version in the Gemfile.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby '2.2.4'
+
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.5'


### PR DESCRIPTION
Doing this enables RVM to automatically switch to that version of ruby when changing directories.