### PR TITLE
Use puma as the application server in development and production.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,3 +45,4 @@ group :development do
   gem 'spring'
 end
 
+gem 'puma'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,7 @@ GEM
     multi_json (1.11.2)
     nokogiri (1.6.7.1)
       mini_portile2 (~> 2.0.0.rc2)
+    puma (2.15.3)
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -145,6 +146,7 @@ DEPENDENCIES
   coffee-rails (~> 4.1.0)
   jbuilder (~> 2.0)
   jquery-rails
+  puma
   rails (= 4.2.5)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)


### PR DESCRIPTION
Puma is the recommended webserver for ruby projects on Heroku [[1](https://devcenter.heroku.com/changelog-items/594)].

By installing puma running `rails start`, puma will load instead of WEBrick in all modes.